### PR TITLE
chore: update api-gateway name

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
+          make integration-test API_GATEWAY_MODEL_HOST=localhost API_GATEWAY_MODEL_PORT=8080
 
       - name: Checkout (model)
         uses: actions/checkout@v3
@@ -128,4 +128,4 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
+          make integration-test API_GATEWAY_MODEL_HOST=localhost API_GATEWAY_MODEL_PORT=8080

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ unit-test:       				## Run unit test
 .PHONY: integration-test
 integration-test:				## Run integration test
 	@TEST_FOLDER_ABS_PATH=${PWD} k6 run \
-		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_HOST=${API_GATEWAY_HOST} -e API_GATEWAY_PORT=${API_GATEWAY_PORT} \
+		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_MODEL_HOST=${API_GATEWAY_MODEL_HOST} -e API_GATEWAY_MODEL_PORT=${API_GATEWAY_MODEL_PORT} \
 		integration-test/grpc.js --no-usage-report --quiet
 
 .PHONY: help

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -4,11 +4,11 @@ let proto
 let mHost, mgHost, ctHost, tHost
 let mPublicPort, mPrivatePort, mgPublicPort, mgPrivatePort, ctPrivatePort, tPublicPort
 
-if (__ENV.API_GATEWAY_HOST && !__ENV.API_GATEWAY_PORT || !__ENV.API_GATEWAY_HOST && __ENV.API_GATEWAY_PORT) {
-  fail("both API_GATEWAY_HOST and API_GATEWAY_PORT should be properly configured.")
+if (__ENV.API_GATEWAY_MODEL_HOST && !__ENV.API_GATEWAY_MODEL_PORT || !__ENV.API_GATEWAY_MODEL_HOST && __ENV.API_GATEWAY_MODEL_PORT) {
+  fail("both API_GATEWAY_MODEL_HOST and API_GATEWAY_MODEL_PORT should be properly configured.")
 }
 
-export const apiGatewayMode = (__ENV.API_GATEWAY_HOST && __ENV.API_GATEWAY_PORT);
+export const apiGatewayMode = (__ENV.API_GATEWAY_MODEL_HOST && __ENV.API_GATEWAY_MODEL_PORT);
 
 if (__ENV.API_GATEWAY_PROTOCOL) {
   if (__ENV.API_GATEWAY_PROTOCOL !== "http" && __ENV.API_GATEWAY_PROTOCOL != "https") {
@@ -21,29 +21,23 @@ if (__ENV.API_GATEWAY_PROTOCOL) {
 
 if (apiGatewayMode) {
   // api-gateway mode
-  mHost = mgHost = ctHost = tHost = __ENV.API_GATEWAY_HOST
+  mHost = ctHost = tHost = __ENV.API_GATEWAY_MODEL_HOST
   mPrivatePort = 3083
-  mgPrivatePort = 3084
   ctPrivatePort = 3086
   mPublicPort = mgPublicPort = tPublicPort = 8080
 } else {
   // direct microservice mode
   mHost = "model-backend"
-  mgHost = "mgmt-backend"
   ctHost = "controller-model"
   tHost = "triton-server"
   mPrivatePort = 3083
-  mgPrivatePort = 3084
   ctPrivatePort = 3086
   mPublicPort = 8083
-  mgPublicPort = 8084
   tPublicPort = 8001
 }
 
 export const modelPublicHost = `${proto}://${mHost}:${mPublicPort}`;
 export const modelPrivateHost = `${proto}://${mHost}:${mPrivatePort}`;
-export const mgmtPublicHost = `${proto}://${mgHost}:${mgPublicPort}`;
-export const mgmtPrivateHost = `${proto}://${mgHost}:${mgPrivatePort}`;
 export const controllerPrivateHost = `${proto}://${ctHost}:${ctPrivatePort}`;
 export const tritonPublicHost = `${proto}://${tHost}:${tPublicPort}`;
 


### PR DESCRIPTION
Because

- Some of our test-cases may be cross projects, we need to use different apigateway endpoints

This commit

- update integration test params
