### PR TITLE
chore: add self readiness check before start probing loop

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -217,10 +217,25 @@ func main() {
 	span.End()
 	logger.Info("gRPC server is running.")
 
-	// Workaround, wait the http server ready
-	time.Sleep(10 * time.Second)
+	clientDialOpts := grpc.WithTransportCredentials(insecure.NewCredentials())
+	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", "127.0.0.1", config.Config.Server.Port), clientDialOpts)
+	if err != nil {
+		panic(err)
+	}
+	defer clientConn.Close()
+
+	controllerClient := controllerPB.NewControllerPrivateServiceClient(clientConn)
 
 	go func() {
+
+		for {
+			resp, err := controllerClient.Readiness(context.Background(), &controllerPB.ReadinessRequest{})
+			logger.Info(fmt.Sprintf("readiness %s", resp))
+			if err == nil {
+				break
+			}
+			time.Sleep(1 * time.Second)
+		}
 
 		logger.Info("[controller] control loop started")
 		var mainWG sync.WaitGroup


### PR DESCRIPTION
Because

- if the probing loop start before the server ready, there will be a lot of racing condition happen

This commit

- add self readiness check before start probing loop
