### PR TITLE
refactor(logging): reduce unnecessary log emission

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -93,7 +93,9 @@ func main() {
 		// can't handle the error due to https://github.com/uber-go/zap/issues/880
 		_ = logger.Sync()
 	}()
-	grpc_zap.ReplaceGrpcLoggerV2(logger)
+
+	// verbosity 3 will avoid [transport] from emitting
+	grpc_zap.ReplaceGrpcLoggerV2WithVerbosity(logger, 3)
 
 	// Create tls based credential.
 	var creds credentials.TransportCredentials
@@ -111,6 +113,10 @@ func main() {
 			// will not log gRPC calls if it was a call to liveness or readiness and no error was raised
 			if err == nil {
 				if match, _ := regexp.MatchString("model.controller.v1alpha.ControllerPrivateService/.*ness$", fullMethodName); match {
+					return false
+				}
+				// stop logging successful private function calls
+				if match, _ := regexp.MatchString("model.model.v1alpha.ModelPrivateService/.*Admin$", fullMethodName); match {
 					return false
 				}
 			}
@@ -222,8 +228,6 @@ func main() {
 		logger.Info("[controller] control loop started")
 		var mainWG sync.WaitGroup
 		for {
-			logger.Info("[controller] --------------Start probing------------")
-
 			for etcdClient.ActiveConnection().GetState() != connectivity.Ready {
 				logger.Warn("[controller] etcd connection lost, waiting for state change...")
 				etcdClient.ActiveConnection().WaitForStateChange(ctx, connectivity.TransientFailure)

--- a/pkg/service/model.go
+++ b/pkg/service/model.go
@@ -77,7 +77,6 @@ func (s *service) ProbeModels(ctx context.Context, cancel context.CancelFunc) er
 				if opInfo.Done {
 					if err := s.DeleteResourceWorkflowID(ctx, resourcePermalink); err != nil {
 						logger.Error(err.Error())
-						return
 					}
 					if opInfo.GetError() != nil {
 						if err = s.UpdateResourceState(ctx, &controllerPB.Resource{
@@ -88,11 +87,7 @@ func (s *service) ProbeModels(ctx context.Context, cancel context.CancelFunc) er
 						}); err != nil {
 							logger.Error(err.Error())
 						}
-						return
 					}
-				} else {
-					logResp, _ := s.GetResourceState(ctx, resourcePermalink)
-					logger.Info(fmt.Sprintf("[Controller] Got %v", logResp))
 					return
 				}
 			}
@@ -114,8 +109,6 @@ func (s *service) ProbeModels(ctx context.Context, cancel context.CancelFunc) er
 			}
 
 			logResp, _ := s.GetResourceState(ctx, resourcePermalink)
-			logger.Info(fmt.Sprintf("[Controller] Got %v", logResp))
-
 			currentState = logResp.GetModelState()
 			desireState = model.State
 
@@ -163,7 +156,7 @@ func (s *service) moveCurrentStateToDesireState(ctx context.Context, modelPermal
 	case modelPB.Model_STATE_ONLINE:
 		switch currentState {
 		case modelPB.Model_STATE_OFFLINE:
-			logger.Info("[Controller] Trying to move model state to desire state")
+			logger.Info(fmt.Sprintf("[Controller] Moving %v from %v to %v", modelPermalink, currentState, desireState))
 			resp, err := s.modelPrivateClient.DeployModelAdmin(ctx, &modelPB.DeployModelAdminRequest{
 				ModelPermalink: modelPermalink,
 			})
@@ -193,7 +186,7 @@ func (s *service) moveCurrentStateToDesireState(ctx context.Context, modelPermal
 	case modelPB.Model_STATE_OFFLINE:
 		switch currentState {
 		case modelPB.Model_STATE_ONLINE:
-			logger.Info("[Controller] Trying to move model state to desire state")
+			logger.Info(fmt.Sprintf("[Controller] Moving %v from %v to %v", modelPermalink, currentState, desireState))
 			resp, err := s.modelPrivateClient.UndeployModelAdmin(ctx, &modelPB.UndeployModelAdminRequest{
 				ModelPermalink: modelPermalink,
 			})

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -254,21 +254,19 @@ func (s *service) ProbeBackend(ctx context.Context, cancel context.CancelFunc) e
 				}
 			}
 
-			err := s.UpdateResourceState(ctx, &controllerPB.Resource{
+			if healthcheck.Status == healthcheckPB.HealthCheckResponse_SERVING_STATUS_NOT_SERVING {
+				logger.Info(fmt.Sprintf("[Controller] %v: %v", hostname, healthcheck.Status))
+			}
+
+			if err := s.UpdateResourceState(ctx, &controllerPB.Resource{
 				ResourcePermalink: util.ConvertServiceToResourceName(hostname),
 				State: &controllerPB.Resource_BackendState{
 					BackendState: healthcheck.Status,
 				},
-			})
-
-			if err != nil {
+			}); err != nil {
 				logger.Error(err.Error())
 				return
 			}
-
-			resp, _ := s.GetResourceState(ctx, util.ConvertServiceToResourceName(hostname))
-
-			logger.Info(fmt.Sprintf("[Controller] Got %v", resp))
 		}(hostname)
 	}
 


### PR DESCRIPTION
Because

- Currently backends in Instill Base Instill VDP and Instill Model will emit a huge amount of logs with level Info, which can overwhelm stdout

This commit

- Refactor grpc logger `verbosity` and bypass successful private function calls
