### PR TITLE
fix(model): fix list model page size

### DIFF
--- a/internal/util/const.go
+++ b/internal/util/const.go
@@ -8,4 +8,4 @@ const (
 	RESOURCE_TYPE_SERVICE               = "services"
 )
 
-const DefaultPageSize = int32(100)
+const DefaultPageSize = int32(10)


### PR DESCRIPTION
Because

- default page size not aligned and cause missing models in response

This commit

- fix default page size
