### PR TITLE
chore(model): fix model deployment reconciliation

### DIFF
--- a/internal/util/const.go
+++ b/internal/util/const.go
@@ -8,4 +8,7 @@ const (
 	RESOURCE_TYPE_SERVICE               = "services"
 )
 
-const DefaultPageSize = int32(10)
+const (
+	DefaultPageSize   = int32(10)
+	DefaultRetryCount = int64(3)
+)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -16,6 +16,12 @@ func ConvertServiceToResourceName(serviceName string) string {
 	return resourceName
 }
 
+func ConvertResourcePermalinkToResourceRetryName(resourcePermalink string) string {
+	resourceWorkflowId := fmt.Sprintf("%s/retry", resourcePermalink)
+
+	return resourceWorkflowId
+}
+
 func ConvertResourcePermalinkToWorkflowName(resourcePermalink string) string {
 	resourceWorkflowId := fmt.Sprintf("%s/workflow", resourcePermalink)
 

--- a/pkg/service/model.go
+++ b/pkg/service/model.go
@@ -63,18 +63,8 @@ func (s *service) ProbeModels(ctx context.Context, cancel context.CancelFunc) er
 			resourcePermalink := util.ConvertUIDToResourcePermalink(model.Uid, resourceType)
 			modelPermalink := fmt.Sprintf("%s/%s", "models", model.Uid)
 
+			// model in transition state
 			workflowID, _ := s.GetResourceWorkflowID(ctx, resourcePermalink)
-
-			var currentState modelPB.Model_State
-			var desireState modelPB.Model_State
-
-			curResp, _ := s.GetResourceState(ctx, resourcePermalink)
-			currentState = curResp.GetModelState()
-
-			if currentState == modelPB.Model_STATE_ERROR {
-				logger.Warn(fmt.Sprintf("[Controller] %s: %v", model.Name, currentState))
-				return
-			}
 
 			if workflowID != nil {
 				opInfo, err := s.getOperationInfo(*workflowID, util.RESOURCE_TYPE_MODEL)
@@ -99,24 +89,40 @@ func (s *service) ProbeModels(ctx context.Context, cancel context.CancelFunc) er
 				}
 				return
 			}
-			if resp, err := s.modelPrivateClient.CheckModelAdmin(ctx, &modelPB.CheckModelAdminRequest{
+
+			// model in end state
+			lastResp, _ := s.GetResourceState(ctx, resourcePermalink)
+			curResp, err := s.modelPrivateClient.CheckModelAdmin(ctx, &modelPB.CheckModelAdminRequest{
 				ModelPermalink: modelPermalink,
-			}); err == nil {
-				if err = s.UpdateResourceState(ctx, &controllerPB.Resource{
-					ResourcePermalink: resourcePermalink,
-					State: &controllerPB.Resource_ModelState{
-						ModelState: resp.State,
-					},
-				}); err != nil {
-					logger.Error(err.Error())
-					return
-				}
-			} else {
+			})
+			if err != nil {
 				logger.Error(err.Error())
 				return
 			}
 
-			desireState = model.State
+			lastProbeState := lastResp.GetModelState()
+			currentState := curResp.GetState()
+			desireState := model.State
+
+			if currentState != modelPB.Model_STATE_ERROR && lastProbeState != modelPB.Model_STATE_ERROR {
+				if err = s.UpdateResourceRetryCount(ctx, resourcePermalink, 0); err != nil {
+					return
+				}
+			}
+
+			if err = s.UpdateResourceState(ctx, &controllerPB.Resource{
+				ResourcePermalink: resourcePermalink,
+				State: &controllerPB.Resource_ModelState{
+					ModelState: currentState,
+				},
+			}); err != nil {
+				logger.Error(err.Error())
+				return
+			}
+
+			if lastProbeState == modelPB.Model_STATE_ERROR {
+				logger.Warn(fmt.Sprintf("[Controller] %s last op errored, trigger retry", model.Name))
+			}
 
 			rModel := ReconcileModel{
 				ModelPermalink:    modelPermalink,
@@ -163,6 +169,9 @@ func (s *service) moveCurrentStateToDesireState(ctx context.Context, modelPermal
 		switch currentState {
 		case modelPB.Model_STATE_OFFLINE:
 			logger.Info(fmt.Sprintf("[Controller] Moving %v from %v to %v", modelPermalink, currentState, desireState))
+			if err := s.checkRetry(ctx, resourcePermalink); err != nil {
+				return err
+			}
 			resp, err := s.modelPrivateClient.DeployModelAdmin(ctx, &modelPB.DeployModelAdminRequest{
 				ModelPermalink: modelPermalink,
 			})
@@ -193,6 +202,9 @@ func (s *service) moveCurrentStateToDesireState(ctx context.Context, modelPermal
 		switch currentState {
 		case modelPB.Model_STATE_ONLINE:
 			logger.Info(fmt.Sprintf("[Controller] Moving %v from %v to %v", modelPermalink, currentState, desireState))
+			if err := s.checkRetry(ctx, resourcePermalink); err != nil {
+				return err
+			}
 			resp, err := s.modelPrivateClient.UndeployModelAdmin(ctx, &modelPB.UndeployModelAdminRequest{
 				ModelPermalink: modelPermalink,
 			})
@@ -221,4 +233,18 @@ func (s *service) moveCurrentStateToDesireState(ctx context.Context, modelPermal
 		}
 	}
 	return err
+}
+
+func (s *service) checkRetry(ctx context.Context, resourcePermalink string) error {
+	// check retry count
+	if retryCount, err := s.GetResourceRetryCount(ctx, resourcePermalink); err != nil {
+		return err
+	} else if *retryCount >= util.DefaultRetryCount {
+		return fmt.Errorf(fmt.Sprintf("[Controller] Retry limit reached for %s", resourcePermalink))
+	} else {
+		if err = s.UpdateResourceRetryCount(ctx, resourcePermalink, *retryCount+int64(1)); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/service/model.go
+++ b/pkg/service/model.go
@@ -130,11 +130,10 @@ func (s *service) ProbeModels(ctx context.Context, cancel context.CancelFunc) er
 					return
 				}
 				logger.Warn(err.Error())
-				return
-			}
-
-			if lastProbeState == modelPB.Model_STATE_ERROR {
-				logger.Warn(fmt.Sprintf("[Controller] %s last op errored, trigger retry", model.Name))
+			} else {
+				if lastProbeState == modelPB.Model_STATE_ERROR {
+					logger.Warn(fmt.Sprintf("[Controller] %s last op errored, trigger retry", model.Name))
+				}
 			}
 
 			rModel := ReconcileModel{
@@ -181,7 +180,7 @@ func (s *service) moveCurrentStateToDesireState(ctx context.Context, modelPermal
 	case modelPB.Model_STATE_ONLINE:
 		switch currentState {
 		case modelPB.Model_STATE_OFFLINE:
-			logger.Info(fmt.Sprintf("[Controller] Moving %v from %v to %v", modelPermalink, currentState, desireState))
+			logger.Info(fmt.Sprintf("[Controller] moving %v from %v to %v", modelPermalink, currentState, desireState))
 			resp, err := s.modelPrivateClient.DeployModelAdmin(ctx, &modelPB.DeployModelAdminRequest{
 				ModelPermalink: modelPermalink,
 			})
@@ -211,7 +210,7 @@ func (s *service) moveCurrentStateToDesireState(ctx context.Context, modelPermal
 	case modelPB.Model_STATE_OFFLINE:
 		switch currentState {
 		case modelPB.Model_STATE_ONLINE:
-			logger.Info(fmt.Sprintf("[Controller] Moving %v from %v to %v", modelPermalink, currentState, desireState))
+			logger.Info(fmt.Sprintf("[Controller] moving %v from %v to %v", modelPermalink, currentState, desireState))
 			resp, err := s.modelPrivateClient.UndeployModelAdmin(ctx, &modelPB.UndeployModelAdminRequest{
 				ModelPermalink: modelPermalink,
 			})
@@ -247,7 +246,7 @@ func (s *service) checkRetry(ctx context.Context, resourcePermalink string) erro
 	if retryCount, err := s.GetResourceRetryCount(ctx, resourcePermalink); err != nil {
 		return err
 	} else if *retryCount >= util.DefaultRetryCount {
-		return fmt.Errorf(fmt.Sprintf("[Controller] Retry limit reached for %s", resourcePermalink))
+		return fmt.Errorf(fmt.Sprintf("[Controller] retry limit reached for %s", resourcePermalink))
 	} else {
 		if err = s.UpdateResourceRetryCount(ctx, resourcePermalink, *retryCount+int64(1)); err != nil {
 			return err

--- a/pkg/service/model.go
+++ b/pkg/service/model.go
@@ -129,6 +129,7 @@ func (s *service) ProbeModels(ctx context.Context, cancel context.CancelFunc) er
 				}); e != nil {
 					return
 				}
+				currentState = lastProbeState
 				logger.Warn(err.Error())
 			} else {
 				if lastProbeState == modelPB.Model_STATE_ERROR {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -139,14 +139,17 @@ func (s *service) UpdateResourceState(ctx context.Context, resource *controllerP
 }
 
 func (s *service) DeleteResourceState(ctx context.Context, resourcePermalink string) error {
-	resourceRetry := util.ConvertResourcePermalinkToResourceRetryName(resourcePermalink)
+	resourceType := strings.SplitN(resourcePermalink, "/", 4)[3]
 
-	_, err := s.etcdClient.Delete(ctx, resourceRetry)
-	if err != nil {
-		return err
+	if resourceType == util.RESOURCE_TYPE_MODEL {
+		resourceRetry := util.ConvertResourcePermalinkToResourceRetryName(resourcePermalink)
+		_, err := s.etcdClient.Delete(ctx, resourceRetry)
+		if err != nil {
+			return err
+		}
 	}
 
-	_, err = s.etcdClient.Delete(ctx, resourcePermalink)
+	_, err := s.etcdClient.Delete(ctx, resourcePermalink)
 	if err != nil {
 		return err
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -17,8 +17,8 @@ import (
 	"github.com/instill-ai/controller-model/pkg/logger"
 
 	inferenceserver "github.com/instill-ai/controller-model/internal/triton"
-	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1alpha"
 	healthcheckPB "github.com/instill-ai/protogen-go/common/healthcheck/v1alpha"
+	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1alpha"
 	controllerPB "github.com/instill-ai/protogen-go/model/controller/v1alpha"
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
@@ -28,6 +28,8 @@ type Service interface {
 	GetResourceState(ctx context.Context, resourcePermalink string) (*controllerPB.Resource, error)
 	UpdateResourceState(ctx context.Context, resource *controllerPB.Resource) error
 	DeleteResourceState(ctx context.Context, resourcePermalink string) error
+	GetResourceRetryCount(ctx context.Context, resourcePermalink string) (*int64, error)
+	UpdateResourceRetryCount(ctx context.Context, resourcePermalink string, retryCount int64) error
 	GetResourceWorkflowID(ctx context.Context, resourcePermalink string) (*string, error)
 	UpdateResourceWorkflowID(ctx context.Context, resourcePermalink string, workflowID string) error
 	DeleteResourceWorkflowID(ctx context.Context, resourcePermalink string) error
@@ -137,7 +139,45 @@ func (s *service) UpdateResourceState(ctx context.Context, resource *controllerP
 }
 
 func (s *service) DeleteResourceState(ctx context.Context, resourcePermalink string) error {
-	_, err := s.etcdClient.Delete(ctx, resourcePermalink)
+	resourceRetry := util.ConvertResourcePermalinkToResourceRetryName(resourcePermalink)
+
+	_, err := s.etcdClient.Delete(ctx, resourceRetry)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.etcdClient.Delete(ctx, resourcePermalink)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *service) GetResourceRetryCount(ctx context.Context, resourcePermalink string) (*int64, error) {
+	resourceRetry := util.ConvertResourcePermalinkToResourceRetryName(resourcePermalink)
+
+	resp, err := s.etcdClient.Get(ctx, resourceRetry)
+
+	if err != nil {
+		return nil, err
+	}
+
+	kvs := resp.Kvs
+
+	if len(kvs) == 0 {
+		return nil, fmt.Errorf("retry count not found in etcd storage")
+	}
+
+	retryCount, _ := strconv.ParseInt(string(kvs[0].Value[:]), 10, 32)
+
+	return &retryCount, nil
+}
+
+func (s *service) UpdateResourceRetryCount(ctx context.Context, resourcePermalink string, retryCount int64) error {
+	resourceRetry := util.ConvertResourcePermalinkToResourceRetryName(resourcePermalink)
+
+	_, err := s.etcdClient.Put(ctx, resourceRetry, fmt.Sprint(retryCount))
 
 	if err != nil {
 		return err

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -20,6 +20,7 @@ import (
 
 const serviceResourceName = "resources/name/types/services"
 const modelResourceName = "resources/name/types/models"
+const modelResourceRetryName = "resources/name/types/models/retry"
 
 type Client struct {
 	etcdv3.Cluster
@@ -255,6 +256,11 @@ func TestDeleteResourceState(t *testing.T) {
 		mockKV.
 			EXPECT().
 			Delete(ctx, modelResourceName).
+			Return(resp, nil).
+			Times(1)
+		mockKV.
+			EXPECT().
+			Delete(ctx, modelResourceRetryName).
 			Return(resp, nil).
 			Times(1)
 


### PR DESCRIPTION
Because

- controller won't attempt to redeploy model if state is in `STATE_ERROR`

This commit

- implement retry mechanism with attempt limit
