### PR TITLE
chore(proto): adopt latest protobuf for beta

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231210131526-67e990838339
 	github.com/knadh/koanf v1.5.0
 	github.com/redis/go-redis/v9 v9.0.2
 	github.com/stretchr/testify v1.8.3

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f h1:hweU93u6qsg8GH/YSogOfa+wOZEnkilGsijcy1xKX7E=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231210131526-67e990838339 h1:Q48Mm+0i6gL4ZYMiHPddMfBQaslk83y3jmPg9T1T7IQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231210131526-67e990838339/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=

--- a/internal/external/external.go
+++ b/internal/external/external.go
@@ -13,7 +13,7 @@ import (
 	"github.com/instill-ai/controller-model/pkg/logger"
 
 	inferenceserver "github.com/instill-ai/controller-model/internal/triton"
-	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1alpha"
+	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 	etcdv3 "go.etcd.io/etcd/client/v3"
 )

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/instill-ai/controller-model/pkg/service"
 
 	custom_otel "github.com/instill-ai/controller-model/pkg/logger/otel"
-	healthcheckPB "github.com/instill-ai/protogen-go/common/healthcheck/v1alpha"
+	healthcheckPB "github.com/instill-ai/protogen-go/common/healthcheck/v1beta"
 	controllerPB "github.com/instill-ai/protogen-go/model/controller/v1alpha"
 )
 

--- a/pkg/service/model.go
+++ b/pkg/service/model.go
@@ -10,7 +10,7 @@ import (
 	"github.com/instill-ai/controller-model/internal/util"
 	"github.com/instill-ai/controller-model/pkg/logger"
 
-	healthcheckPB "github.com/instill-ai/protogen-go/common/healthcheck/v1alpha"
+	healthcheckPB "github.com/instill-ai/protogen-go/common/healthcheck/v1beta"
 	controllerPB "github.com/instill-ai/protogen-go/model/controller/v1alpha"
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -17,8 +17,8 @@ import (
 	"github.com/instill-ai/controller-model/pkg/logger"
 
 	inferenceserver "github.com/instill-ai/controller-model/internal/triton"
-	healthcheckPB "github.com/instill-ai/protogen-go/common/healthcheck/v1alpha"
-	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1alpha"
+	healthcheckPB "github.com/instill-ai/protogen-go/common/healthcheck/v1beta"
+	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	controllerPB "github.com/instill-ai/protogen-go/model/controller/v1alpha"
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/instill-ai/controller-model/pkg/service"
 
-	healthcheckPB "github.com/instill-ai/protogen-go/common/healthcheck/v1alpha"
+	healthcheckPB "github.com/instill-ai/protogen-go/common/healthcheck/v1beta"
 	controllerPB "github.com/instill-ai/protogen-go/model/controller/v1alpha"
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )


### PR DESCRIPTION
Because

- we are going to upgrade core protobufs to beta version

This commit

- upgrade core protobufs to beta version