### PR TITLE
feat(cache): add cache retention monitoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ dev:							## Run dev container
 	@docker run -d --rm \
 		-e DOCKER_HOST=${SOCAT_HOST}:${SOCAT_PORT} \
 		-e CFG_ETCD_PORT=${ETCD_CLIENT_PORT} \
+		-v model-repository:/model-repository \
 		-v $(PWD):/${SERVICE_NAME} \
 		-p ${SERVICE_PORT}:${SERVICE_PORT} \
 		--network instill-network \

--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,11 @@ type CacheConfig struct {
 	Redis struct {
 		RedisOptions redis.Options `koanf:"redisoptions"`
 	}
+	Model struct {
+		Enabled         bool   `koanf:"enabled"`
+		CacheDir        string `koanf:"cache_dir"`
+		RetentionPeriod string `koanf:"retentionperiod"`
+	}
 }
 
 // TritonServerConfig related to Triton server

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,6 +19,14 @@ modelbackend:
   https:
     cert:
     key:
+cache:
+  redis:
+    redisoptions:
+      addr: redis:6379
+  model:
+    enabled: false
+    cache_dir: /model-repository/.cache/models
+    retentionperiod: 24h
 mgmtbackend:
   host: mgmt-backend
   publicport: 8084

--- a/pkg/service/cache.go
+++ b/pkg/service/cache.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/instill-ai/controller-model/config"
+	"github.com/instill-ai/controller-model/pkg/logger"
+)
+
+func (s *service) MonitorModelCache(ctx context.Context, cancel context.CancelFunc) error {
+	defer cancel()
+
+	logger, _ := logger.GetZapLogger(ctx)
+
+	var wg sync.WaitGroup
+
+	iter := s.redisClient.Scan(ctx, 0, "instill-ai/*", 0).Iterator()
+
+	for iter.Next(ctx) {
+		wg.Add(1)
+		go func(key string) {
+			defer wg.Done()
+
+			idleTime, err := s.redisClient.ObjectIdleTime(ctx, key).Result()
+			if err != nil {
+				logger.Error(err.Error())
+				return
+			}
+
+			retentionPeriod, err := time.ParseDuration(config.Config.Cache.Model.RetentionPeriod)
+			if err != nil {
+				logger.Error(err.Error())
+				return
+			}
+
+			pathSplit := strings.Split(key, ":")
+			modelPath := config.Config.Cache.Model.CacheDir + "/" + fmt.Sprintf("%s_%s", pathSplit[0], pathSplit[1])
+
+			if idleTime >= retentionPeriod {
+				err := os.RemoveAll(modelPath)
+				if err != nil {
+					logger.Error(err.Error())
+					return
+				}
+				_, err = s.redisClient.Del(ctx, key).Result()
+				if err != nil {
+					logger.Error(err.Error())
+					return
+				}
+			}
+
+		}(iter.Val())
+	}
+
+	wg.Wait()
+
+	return nil
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/longrunning/autogen/longrunningpb"
+	"github.com/redis/go-redis/v9"
 
 	etcdv3 "go.etcd.io/etcd/client/v3"
 
@@ -35,6 +36,7 @@ type Service interface {
 	DeleteResourceWorkflowID(ctx context.Context, resourcePermalink string) error
 	ProbeBackend(ctx context.Context, cancel context.CancelFunc) error
 	ProbeModels(ctx context.Context, cancel context.CancelFunc) error
+	MonitorModelCache(ctx context.Context, cancel context.CancelFunc) error
 }
 
 type service struct {
@@ -43,6 +45,7 @@ type service struct {
 	mgmtPublicClient   mgmtPB.MgmtPublicServiceClient
 	tritonClient       inferenceserver.GRPCInferenceServiceClient
 	etcdClient         etcdv3.Client
+	redisClient        *redis.Client
 }
 
 // NewService returns a new service instance
@@ -51,13 +54,15 @@ func NewService(
 	m modelPB.ModelPrivateServiceClient,
 	mg mgmtPB.MgmtPublicServiceClient,
 	t inferenceserver.GRPCInferenceServiceClient,
-	e etcdv3.Client) Service {
+	e etcdv3.Client,
+	r *redis.Client) Service {
 	return &service{
 		modelPublicClient:  mp,
 		modelPrivateClient: m,
 		mgmtPublicClient:   mg,
 		tritonClient:       t,
 		etcdClient:         e,
+		redisClient:        r,
 	}
 }
 

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -67,7 +67,7 @@ func TestGetResourceState(t *testing.T) {
 			Return(resp, nil).
 			Times(1)
 
-		s := service.NewService(nil, nil, nil, nil, mockEtcdClient)
+		s := service.NewService(nil, nil, nil, nil, mockEtcdClient, nil)
 
 		resource, err := s.GetResourceState(ctx, serviceResourceName)
 
@@ -102,7 +102,7 @@ func TestGetResourceState(t *testing.T) {
 			Return(resp, nil).
 			Times(1)
 
-		s := service.NewService(nil, nil, nil, nil, mockEtcdClient)
+		s := service.NewService(nil, nil, nil, nil, mockEtcdClient, nil)
 
 		resource, err := s.GetResourceState(ctx, modelResourceName)
 
@@ -148,7 +148,7 @@ func TestUpdateResourceState(t *testing.T) {
 			Return(&etcdv3.PutResponse{}, nil).
 			Times(1)
 
-		s := service.NewService(nil, nil, nil, nil, mockEtcdClient)
+		s := service.NewService(nil, nil, nil, nil, mockEtcdClient, nil)
 
 		err := s.UpdateResourceState(ctx, &resource)
 
@@ -187,7 +187,7 @@ func TestUpdateResourceState(t *testing.T) {
 			Return(&etcdv3.PutResponse{}, nil).
 			Times(1)
 
-		s := service.NewService(nil, nil, nil, nil, mockEtcdClient)
+		s := service.NewService(nil, nil, nil, nil, mockEtcdClient, nil)
 
 		err := s.UpdateResourceState(ctx, &resource)
 
@@ -226,7 +226,7 @@ func TestDeleteResourceState(t *testing.T) {
 			Return(resp, nil).
 			Times(1)
 
-		s := service.NewService(nil, nil, nil, nil, mockEtcdClient)
+		s := service.NewService(nil, nil, nil, nil, mockEtcdClient, nil)
 
 		err := s.DeleteResourceState(ctx, serviceResourceName)
 
@@ -264,7 +264,7 @@ func TestDeleteResourceState(t *testing.T) {
 			Return(resp, nil).
 			Times(1)
 
-		s := service.NewService(nil, nil, nil, nil, mockEtcdClient)
+		s := service.NewService(nil, nil, nil, nil, mockEtcdClient, nil)
 
 		err := s.DeleteResourceState(ctx, modelResourceName)
 


### PR DESCRIPTION
Because

- support model cache retention monitoring

This commit

- add redis client
- add cache monitor loop

resolves ins-3370