### PR TITLE
ci(workflows): adopt latest project structure

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         component: [model-backend]
-    uses: instill-ai/model/.github/workflows/integration-test-backend.yml@main
+    uses: instill-ai/instill-core/.github/workflows/integration-test-backend.yml@main
     with:
       component: ${{ matrix.component }}
       target: latest
@@ -71,10 +71,10 @@ jobs:
           envFile: .env
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           load: true
@@ -83,12 +83,12 @@ jobs:
             GOLANG_VERSION=${{ env.GOLANG_VERSION }}
           tags: instill/${{ env.SERVICE_NAME }}:latest
 
-      - name: Checkout repo (core)
-        uses: actions/checkout@v3
+      - name: Checkout repo (instill-core)
+        uses: actions/checkout@v4
         with:
-          repository: instill-ai/core
+          repository: instill-ai/instill-core
 
-      - name: Load .env file (core)
+      - name: Load .env file (instill-core)
         uses: cardinalby/export-env-action@v2
         with:
           envFile: .env
@@ -97,30 +97,12 @@ jobs:
         run: |
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
-          docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
-          COMPOSE_PROFILES=all \
-          EDITION=local-ce:test \
-          docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
-
-      - name: Checkout repo (model)
-        uses: actions/checkout@v3
-        with:
-          repository: instill-ai/model
-
-      - name: Load .env file (model)
-        uses: cardinalby/export-env-action@v2
-        with:
-          envFile: .env
-
-      - name: Launch Instill Model (latest)
-        run: |
-          EDITION=local-ce:test \
+          RAY_LATEST_TAG=latest \
           ITMODE_ENABLED=true \
-          RAY_PLATFORM=cpu \
+          docker compose -f docker-compose.yml -f docker-compose-latest.yml up -d --quiet-pull
           COMPOSE_PROFILES=all \
-          docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
           EDITION=local-ce:test \
-          docker compose -f docker-compose.yml -f docker-compose.latest.yml rm -f
+          docker compose -f docker-compose.yml -f docker-compose-latest.yml rm -f
 
       - name: Install k6
         run: |


### PR DESCRIPTION
Because

- we refactored the entire Instill project structure, the existing GA won't work.

This commit

- adopts latest project structure